### PR TITLE
feat: バックエンドデータを活用したハッカソン選択機能の実装

### DIFF
--- a/src/app/(home)/home/components/MatchingPopup.tsx
+++ b/src/app/(home)/home/components/MatchingPopup.tsx
@@ -15,7 +15,7 @@ import { Confetti } from '@/components/ui/confetti'
 interface HackathonInfo {
   name: string
   url: string
-  description?: string
+  description: string
 }
 
 /**
@@ -50,6 +50,7 @@ export default function MatchingPopup({
   type FormState = {
     hackathonName: string
     ogp: string
+    description: string
     period: string
     positions: Record<string, number>
     deadline: string
@@ -57,7 +58,6 @@ export default function MatchingPopup({
     message: string
     customRoles: string[]
     newRole: string
-    // description?: string // 使う場合は追加
   }
   type FormAction =
     | { type: 'SET_ALL'; payload: Partial<FormState> }
@@ -67,6 +67,7 @@ export default function MatchingPopup({
   const getInitialFormState = (hackathonName?: string): FormState => ({
     hackathonName: hackathonName || '',
     ogp: '',
+    description: '',
     period: '',
     positions: { front: 0, back: 0, ai: 0, designer: 0, infra: 0, manager: 0 },
     deadline: '',
@@ -112,6 +113,7 @@ export default function MatchingPopup({
         payload: {
           hackathonName: initialHackathonName,
           ogp: selected?.url || '',
+          description: selected?.description || '',
         },
       })
     } else {
@@ -152,6 +154,7 @@ export default function MatchingPopup({
         payload: {
           hackathonName: initialHackathonName,
           ogp: selected?.url || '',
+          description: selected?.description || '',
           period: '',
           positions: { front: 0, back: 0, ai: 0, designer: 0, infra: 0, manager: 0 },
           deadline: '',
@@ -245,7 +248,7 @@ export default function MatchingPopup({
                 payload: {
                   hackathonName: selected?.name || '',
                   ogp: selected?.url || '',
-                  // description: selected?.description || '',
+                  description: selected?.description || '',
                 },
               })
             }}
@@ -257,6 +260,14 @@ export default function MatchingPopup({
               </option>
             ))}
           </select>
+
+          {/* 選択されたハッカソンの説明を表示 */}
+          {form.description && (
+            <div className='bg-blue-50 border border-blue-200 rounded-lg p-3 mt-2'>
+              <p className='text-sm text-blue-800 leading-relaxed'>{form.description}</p>
+            </div>
+          )}
+
           <label className='font-bold text-sm'>ハッカソン実施期間</label>
           <Input
             type='text'

--- a/src/app/(home)/home/components/SidebarRight.tsx
+++ b/src/app/(home)/home/components/SidebarRight.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Bell, Star, Plus, Mail, Users } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import MatchingPopup from './MatchingPopup'
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import RecommendedHackathonCard from './RecommendedHackathonCard'
 import {
   Carousel,
@@ -21,13 +21,14 @@ export default function SidebarRight() {
   const [selectedHackathon, setSelectedHackathon] = useState<string | undefined>(undefined)
   const { hackathons, loading, error } = useHackathons()
 
-  const recommendedHackathons = [
-    {
-      name: 'Zenn AI Agent Hackathon',
-      url: 'https://static.zenn.studio/permanent/hackathon/google-cloud-japan-ai-hackathon-vol2/header_v2.png',
-    },
-    // 今後ここに追加可能
-  ]
+  // バックエンドのハッカソンデータをMatchingPopup用の形式に変換
+  const recommendedHackathons = useMemo(() => {
+    return hackathons.map((hackathon) => ({
+      name: hackathon.name,
+      url: hackathon.banner_url || '/default.png',
+      description: hackathon.description,
+    }))
+  }, [hackathons])
 
   return (
     <aside className='hidden lg:flex flex-col border-l bg-gradient-to-b from-white/80 to-slate-50/80 backdrop-blur-sm h-full border-white/30'>


### PR DESCRIPTION
- SidebarRight: 静的なrecommendedHackathons配列を削除し、useMemoでバックエンドデータを変換
- MatchingPopup: descriptionフィールドを必須にし、ハッカソン選択時に説明文を表示
- データの一元管理を実現し、バックエンドの更新が自動的にUIに反映されるように改善